### PR TITLE
Create notifyScript.sh

### DIFF
--- a/esercizio_5/notifyScript.sh
+++ b/esercizio_5/notifyScript.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Autore: Matteo Pastorelli
+# Nome: notifyScript.sh
+# Funzione: Monitorare lo stato del servizio Apache e le modifiche sul file fileToMonitor
+# ----------------------------------------------------
+
+# Varibili
+
+fileToMonitor="/etc/myprogram.conf"
+emailToNotify="matteo.pastorelli@libero.it"
+last=`ls -l "$fileToMonitor"`
+
+while true; do
+  sleep 1
+
+# Viene controllato lo stato del servizio apache ed in caso sia spento invia mail
+  if [ $(/etc/init.d/apache2 status | grep -i 'Apache2 is running'  | wc -l) == 0 ]
+    then
+     echo -e "!! WARNING !! : Service Apache2 Spento su SERVER $(hostname)" | /usr/bin/mail -s "URGENTE - Service Apache2 spento su SERVER $(hostname)" $emailToNotify
+
+  fi
+
+# Viene monitorata la data di modifica del file ed in caso di modifica recente invia mail
+
+  new=`ls -l $fileToMonitor`
+  if [ "$new" != "$last" ]; then
+    echo -e "!! WARNING !! : File $fileToMonitor modificato su SERVER $(hostname)" | /usr/bin/mail -s "URGENTE - FILE MODIFICATO su SERVER $(hostname)" $emailToNotify
+    last="$new"
+  fi
+done


### PR DESCRIPTION
Lo script monitora il servizio apache 2, e deve essere installato sulle 25 vm da monitorare, non necessita di particolari pacchetti. In alternativa potrebbe essere installato ed usato il pacchetto inotify-tools, che ho testato velocemente ma di cui non ho esprienza, con un comando 

while true;
do
 inotifywait -e modify /etc/myprogram.conf
 echo -e "File modificato!!"
done

In caso volesse essere adattato per monitorare il servizio httpd è sufficiente modificare il comando che rivela lo stato del servizio httpd, quindi "service httpd status" oppure "ps aux | grep -i httpd".
