### PR TITLE
Create Shop Catalog Dockerfile

### DIFF
--- a/esercizio_2/Shop Catalog Dockerfile
+++ b/esercizio_2/Shop Catalog Dockerfile
@@ -1,0 +1,15 @@
+#
+# Build stage
+#
+FROM maven:3-jdk-12 AS build
+COPY src /home/app/src
+COPY pom.xml /home/app
+RUN mvn -f /home/app/pom.xml clean package
+
+#
+# Package stage
+#
+FROM openjdk:12
+COPY --from=build /home/app/target/shop_catalog-0.0.1-SNAPSHOT.jar /usr/local/lib/demo.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/usr/local/lib/shop_catalog.jar"]


### PR DESCRIPTION
Dockerfile per app Shop Catalog, viene impiegato multi stage building per ridurre dimensione della immagine. Volendo utilizzare la cache per le dipendenze maven è possibile usare il comando RUN mvn dependency:go-offline oppure utilizzare il plugin: maven-dependency-plugin:3.1.1